### PR TITLE
Use "#!/usr/bin/env perl".

### DIFF
--- a/bin/vidir
+++ b/bin/vidir
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings FATAL => 'all';
 use utf8;


### PR DESCRIPTION
I just realized I made this change some time ago and was wondering why it wasn't like that already. Not that I think it should be like this, I was really wondering if there is a reason :smile: it's not.
