### PR TITLE
Change editor priority: use $EDITOR over /usr/bin/editor

### DIFF
--- a/bin/vidir
+++ b/bin/vidir
@@ -71,11 +71,11 @@ my @editor = 'vi';
 if(exists($ENV{VIDIR_EDITOR})) {
   @editor = $ENV{VIDIR_EDITOR};
 }
-elsif(-x '/usr/bin/editor') {
-  @editor = '/usr/bin/editor';
-}
 elsif(exists($ENV{EDITOR})) {
   @editor = split(' ', $ENV{EDITOR});
+}
+elsif(-x '/usr/bin/editor') {
+  @editor = '/usr/bin/editor';
 }
 elsif(exists($ENV{VISUAL})) {
   @editor = split(' ', $ENV{VISUAL});


### PR DESCRIPTION
Two arguments for that change:
- This matches the behavior of git.
- Sublime Text is not trivial to use with /usr/bin/editor. Indeed sublime requires a -w flag to enable the "pipable" behavior used by vidir, and it's not trivial to set this flag with update-alternatives (it uses a syslink).