### PR TITLE
Write and reread temp file in "raw" mode

### DIFF
--- a/bin/vidir
+++ b/bin/vidir
@@ -61,7 +61,7 @@ if (grep(/[[:cntrl:]]/, @sorted)) {
 }
 
 my $tmp=File::Temp->new(TEMPLATE => "dirXXXXX", DIR => File::Spec->tmpdir);
-open (OUT, ">".$tmp->filename) || die "$0: cannot create ".$tmp->filename.": $!\n";
+open (OUT, ">:raw", $tmp->filename) || die "$0: cannot create ".$tmp->filename.": $!\n";
 
 my %item;
 my %done;
@@ -95,7 +95,7 @@ else {
   system(@editor,  $tmp);
 }
 
-open (IN, $tmp->filename) || die "$0: cannot read ".$tmp->filename.": $!\n";
+open (IN, '<:raw', $tmp->filename) || die "$0: cannot read ".$tmp->filename.": $!\n";
 while (<IN>) {
   chomp;
   if(/^\s*(\d+) {0,1}(.*)/) {


### PR DESCRIPTION
This avoids double-encoding of UTF8 characters when a directory
is read via opendir/readdir.

Example:

mkdir xxx
touch xxx/äußerst
vidir xxx
=>
---------------------------
     1 xxx/Ã¤uÃ<9f>erst
---------------------------