### PR TITLE
Make file numbers left-aligned

### DIFF
--- a/bin/vidir
+++ b/bin/vidir
@@ -66,9 +66,10 @@ open (OUT, ">".$tmp->filename) || die "$0: cannot create ".$tmp->filename.": $!\
 my %item;
 my %done;
 my $c=0;
+my $digits=int(1+log(scalar @sorted)/log(10));
 foreach (@sorted) {
   $item{++$c}=$_;
-  print OUT sprintf("%5d %s\n", $c, $_);
+  print OUT sprintf("%*d %s\n", $digits, $c, $_);
 }
 @sorted=();
 close OUT || die "$0: cannot write ".$tmp->filename.": $!\n";


### PR DESCRIPTION
I originally used your version of vidir because of the aligned
file names. This improvement here makes the numbers take only
as many characters as necessary (1 for <10 files, 2 for <100, ...)