### PR TITLE
Sort directory contents when read via readdir

### DIFF
--- a/bin/vidir
+++ b/bin/vidir
@@ -37,7 +37,7 @@ for my $item(@ARGV) {
   }
   if(-d $item) {
     opendir(my $dh, $item) or die "Cant opendir $item: $!\n";
-    for(grep { ! /\A[.]{1,2}\Z/ } readdir($dh)) {
+    for(sort grep { ! /\A[.]{1,2}\Z/ } readdir($dh)) {
       $item =~ s{/$}{};
       if(-d "$item/$_") {
         push(@directories, "$item/$_/");


### PR DESCRIPTION
This can of course also be achieved with your --sort option,
but that one sorts _everything_. This little fix just pulls
a directory's contents in sorted order if one is given on the
command line (or implied by just calling vidir without parameters).